### PR TITLE
Add style classes to message box grids

### DIFF
--- a/src/MessageBox.Avalonia/Views/MsBoxCustomWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxCustomWindow.xaml
@@ -42,7 +42,7 @@
         </Style>
 
   </Window.Styles>
-  <Grid>
+  <Grid Classes="MsBoxCustomContainer">
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="15" />
       <ColumnDefinition Width="Auto" />

--- a/src/MessageBox.Avalonia/Views/MsBoxHyperlinkWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxHyperlinkWindow.xaml
@@ -45,7 +45,7 @@
     </Style>
 
   </Window.Styles>
-  <Grid>
+  <Grid Classes="MsBoxHyperlinkContainer">
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="15" />
       <ColumnDefinition Width="Auto" />

--- a/src/MessageBox.Avalonia/Views/MsBoxInputWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxInputWindow.xaml
@@ -50,7 +50,7 @@
         </Style>
 
     </Window.Styles>
-    <Grid>
+    <Grid Classes="MsBoxInputContainer">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="15" />
             <ColumnDefinition Width="Auto" />

--- a/src/MessageBox.Avalonia/Views/MsBoxStandardWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxStandardWindow.xaml
@@ -45,7 +45,7 @@
         </Style>
 
     </Window.Styles>
-    <Grid>
+    <Grid Classes="MsBoxStandardContainer">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="15" />
             <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
This PR adds style classes to the Grid components of the views of all message boxes. This makes it miles easier for users to change the styling of the message boxes.
![image](https://user-images.githubusercontent.com/31664665/110360307-da13f200-803e-11eb-9648-82212be40b85.png)
