### PR TITLE
Improve InputBox with password reveal modes

### DIFF
--- a/src/MessageBox.Avalonia.Example/MainWindow.xaml.cs
+++ b/src/MessageBox.Avalonia.Example/MainWindow.xaml.cs
@@ -112,6 +112,7 @@ namespace MessageBox.Avalonia.Example
                     ContentHeader = "Input your admin password below",
                     ContentMessage = "Password:",
                     IsPassword = true,
+                    PasswordRevealMode = MessageBoxInputParams.PasswordRevealModes.Hold,
                     ButtonDefinitions = new[] {
                         new ButtonDefinition {Name = "Cancel", IsCancel = true},
                         new ButtonDefinition {Name = "Confirm", Type = ButtonType.Colored, IsDefault = true}

--- a/src/MessageBox.Avalonia.Example/MessageBox.Avalonia.Example.csproj
+++ b/src/MessageBox.Avalonia.Example/MessageBox.Avalonia.Example.csproj
@@ -13,8 +13,8 @@
     </AvaloniaResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.4" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.4" />
+    <PackageReference Include="Avalonia" Version="0.10.5" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MessageBox.Avalonia\MessageBox.Avalonia.csproj" />

--- a/src/MessageBox.Avalonia/DTO/MessageBoxInputParams.cs
+++ b/src/MessageBox.Avalonia/DTO/MessageBoxInputParams.cs
@@ -17,7 +17,7 @@ namespace MessageBox.Avalonia.DTO
             Toggle,
 
             /// <summary>
-            /// Left click and hold to temporary reveal the password
+            /// Left or right click and hold to temporary reveal the password
             /// </summary>
             Hold,
 

--- a/src/MessageBox.Avalonia/DTO/MessageBoxInputParams.cs
+++ b/src/MessageBox.Avalonia/DTO/MessageBoxInputParams.cs
@@ -4,10 +4,32 @@ namespace MessageBox.Avalonia.DTO
 {
     public class MessageBoxInputParams : MessageBoxCustomParams
     {
+        public enum PasswordRevealModes : byte
+        {
+            /// <summary>
+            /// Don't show the reveal button
+            /// </summary>
+            None,
+
+            /// <summary>
+            /// Left click to toggle the reveal password
+            /// </summary>
+            Toggle,
+
+            /// <summary>
+            /// Left click and hold to temporary reveal the password
+            /// </summary>
+            Hold,
+
+            /// <summary>
+            /// Left click to toggle the reveal password | Right click and hold will temporary reveal password
+            /// </summary>
+            Both,
+        }
         public Icon Icon { get; set; } = Icon.None;
         public bool IsPassword { get; set; } = false;
+        public PasswordRevealModes PasswordRevealMode { get; set; } = PasswordRevealModes.Hold;
         public string WatermarkText { get; set; } = null;
-
         public bool Multiline { get; set; }
     }
 }

--- a/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
+++ b/src/MessageBox.Avalonia/MessageBox.Avalonia.csproj
@@ -23,7 +23,7 @@
         </AvaloniaResource>
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Avalonia" Version="0.10.4" />
+      <PackageReference Include="Avalonia" Version="0.10.5" />
     </ItemGroup>
 
 </Project>

--- a/src/MessageBox.Avalonia/ViewModels/MsBoxInputViewModel.cs
+++ b/src/MessageBox.Avalonia/ViewModels/MsBoxInputViewModel.cs
@@ -1,21 +1,41 @@
+using System;
 using MessageBox.Avalonia.DTO;
 using MessageBox.Avalonia.Models;
 using MessageBox.Avalonia.Views;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using MessageBox.Avalonia.Enums;
 
 namespace MessageBox.Avalonia.ViewModels
 {
     public class MsBoxInputViewModel : AbstractMsBoxViewModel
     {
+        private readonly ToggleButton _passwordRevealBtn;
         private readonly MsBoxInputWindow _window;
         private string _inputText;
-        public char? PassChar { get; }
+        private char? _passChar;
+        public char? InitialPassChar { get; }
+
+        public char? PassChar
+        {
+            get => _passChar;
+            private set
+            {
+                _passChar = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public MessageBoxInputParams.PasswordRevealModes PasswordRevealMode { get; }
+
+        public bool IsPasswordRevealButtonVisible => InitialPassChar == '*' && PasswordRevealMode != MessageBoxInputParams.PasswordRevealModes.None;
+
         public string WatermarkText { get; }
 
-        public bool Multiline { get; set; }
+        public bool Multiline { get; }
         // public ReactiveCommand<string, Unit> ButtonClickCommand { get; private set; }
 
         public IEnumerable<ButtonDefinition> ButtonDefinitions { get; }
@@ -34,7 +54,8 @@ namespace MessageBox.Avalonia.ViewModels
         {
             _window = msBoxInputWindow;
             ButtonDefinitions = @params.ButtonDefinitions;
-            PassChar = @params.IsPassword ? '*' : null;
+            InitialPassChar = PassChar = @params.IsPassword ? '*' : null;
+            PasswordRevealMode = @params.PasswordRevealMode;
             WatermarkText = @params.WatermarkText;
             Multiline = @params.Multiline;
 
@@ -53,6 +74,41 @@ namespace MessageBox.Avalonia.ViewModels
                 var grid = _window.FindControl<Grid>("ContentGrid");
                 grid.RowDefinitions[0].Height = GridLength.Parse("*");
             }
+            
+            _passwordRevealBtn = _window.FindControl<ToggleButton>("PasswordRevealBtn");
+
+            _passwordRevealBtn.PointerMoved += (sender, e) =>
+            { // Due avalonia, we cant capture PointerPressed with left mouse click.. So i'm using PointerMoved instead
+              // https://github.com/AvaloniaUI/Avalonia/issues/5952
+                if (!IsPasswordRevealButtonVisible) return;
+
+                var pointer = e.GetCurrentPoint(_passwordRevealBtn);
+
+                if (pointer.Properties.IsLeftButtonPressed && PasswordRevealMode == MessageBoxInputParams.PasswordRevealModes.Hold ||
+                    pointer.Properties.IsRightButtonPressed && PasswordRevealMode == MessageBoxInputParams.PasswordRevealModes.Both)
+                {
+                    PassChar = null;
+                    _passwordRevealBtn.IsChecked = true;
+                    e.Handled = true;
+                }
+            };
+            _passwordRevealBtn.PointerLeave += (sender, e) =>
+            {
+                if (!IsPasswordRevealButtonVisible || PasswordRevealMode != MessageBoxInputParams.PasswordRevealModes.Hold) return;
+
+                PassChar = InitialPassChar;
+                _passwordRevealBtn.IsChecked = false;
+                e.Handled = true;
+            };
+            _passwordRevealBtn.PointerReleased += (sender, e) =>
+            {
+                if (!IsPasswordRevealButtonVisible || PasswordRevealMode != MessageBoxInputParams.PasswordRevealModes.Both) return;
+                if (e.InitialPressMouseButton != MouseButton.Right) return;
+
+                PassChar = InitialPassChar;
+                _passwordRevealBtn.IsChecked = false;
+                e.Handled = true;
+            };
         }
         
         public void ButtonClick(string parameter)
@@ -69,6 +125,25 @@ namespace MessageBox.Avalonia.ViewModels
 
             _window.Close();
             // Code for executing the command here.
+        }
+
+        public void PasswordRevealClick()
+        {
+            if (!IsPasswordRevealButtonVisible) return;
+            switch (PasswordRevealMode)
+            {
+                case MessageBoxInputParams.PasswordRevealModes.Toggle:
+                case MessageBoxInputParams.PasswordRevealModes.Both:
+                    PassChar = _passwordRevealBtn.IsChecked.Value ? null : InitialPassChar;
+                    break;
+                case MessageBoxInputParams.PasswordRevealModes.Hold:
+                    _passwordRevealBtn.IsChecked = false;
+                    PassChar = InitialPassChar;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            
         }
     }
 }

--- a/src/MessageBox.Avalonia/Views/MsBoxInputWindow.xaml
+++ b/src/MessageBox.Avalonia/Views/MsBoxInputWindow.xaml
@@ -83,17 +83,21 @@
             <!--Bold text-->
             <TextBox Grid.Row="0" Classes="header" FontFamily="{Binding FontFamily}" Text="{Binding ContentHeader}" IsVisible="{Binding HasHeader}" />
             <!--Content text-->
-            <Grid Name="ContentGrid" Grid.Row="2" RowDefinitions="Auto" ColumnDefinitions="Auto,5,*">
+            <Grid Name="ContentGrid" Grid.Row="2" RowDefinitions="Auto" ColumnDefinitions="Auto,5,*,Auto">
                 <TextBox FontFamily="{Binding FontFamily}" Text="{Binding ContentMessage}" Grid.Column="0"/>
                 <!--Input field-->
-                <TextBox Name="InputBox" Classes="inputbox" 
-                         Grid.Row="0"
-                         Grid.Column="2"
-                         FontFamily="{Binding FontFamily}" 
-                         Text="{Binding InputText}"  
-                         Watermark="{Binding WatermarkText}" 
-                         PasswordChar="{Binding PassChar}"
-                         AcceptsReturn="{Binding Multiline}"/>
+                    <TextBox Name="InputBox" Classes="inputbox"
+                             Grid.Row="0" Grid.Column="2"
+                             FontFamily="{Binding FontFamily}"
+                             Text="{Binding InputText}"
+                             Watermark="{Binding WatermarkText}"
+                             PasswordChar="{Binding PassChar}"
+                             AcceptsReturn="{Binding Multiline}"/>
+                <ToggleButton Grid.Row="0" Grid.Column="3"
+                              Classes="passwordrevealbtn"
+                              Command="{Binding PasswordRevealClick}"
+                              Name="PasswordRevealBtn" Content="👁"
+                              IsVisible="{Binding IsPasswordRevealButtonVisible}"/>
             </Grid>
 
 

--- a/src/MessageBox.Avalonia/Views/MsBoxStandardWindow.xaml.cs
+++ b/src/MessageBox.Avalonia/Views/MsBoxStandardWindow.xaml.cs
@@ -34,10 +34,12 @@ namespace MessageBox.Avalonia.Views
             base.OnOpened(e);
             
             // Hack to fix scroll bar and limits
-            SizeToContent = SizeToContent.Manual;
-            Width--;
-            Height--;
-            
+            if (SizeToContent != SizeToContent.Manual)
+            {
+                SizeToContent = SizeToContent.Manual;
+                Width--;
+                Height--;
+            }
         }
     }
 }


### PR DESCRIPTION
* Add PasswordRevealMode to InputBox
* Bump avalonia version to 0.10.5 to fix the copy text problem on readonly textbox

![image](https://user-images.githubusercontent.com/113281/118872492-86e0da00-b8e0-11eb-8912-ba04bd2bfe3c.png)
![image](https://user-images.githubusercontent.com/113281/118871625-a4617400-b8df-11eb-87f2-abba96903e95.png)

Eye is UTF-8 text, fix to fixed icon if you think is better to, also if go that route, switch between close and open eye